### PR TITLE
Handle incomplete strings with internal whitespace

### DIFF
--- a/src/net/cgrand/sjacket/parser.clj
+++ b/src/net/cgrand/sjacket/parser.clj
@@ -47,10 +47,14 @@
    :nil (token "nil")
    :boolean #{(token "true") (token "false")}
    :char (re/regex \\ (re/+ token-char))
-   :string (re/regex \" (re/* #{(cs/not \" \\)
-                                [\\ (cs/charset "trn\\\"bf")]
-                                ["\\u" {\0 \9} (re/repeat constituent-char 3 3)]
-                                ["\\" {\0 \9} (re/repeat constituent-char 0 2)]}) \") 
+   :string (p/unspaced
+              ["\""
+               (re/regex
+                   (re/* #{(cs/not \" \\)
+                           [\\ (cs/charset "trn\\\"bf")]
+                           ["\\u" {\0 \9} (re/repeat constituent-char 3 3)]
+                           ["\\" {\0 \9} (re/repeat constituent-char 0 2)]}))
+               "\""])
    :regex "#TODO" ; TODO
    ;; numbers should be validated but this is the exact "scope" of a number
    :number (re/regex (re/? #{\+ \-}) {\0 \9} (re/* constituent-char))

--- a/test/net/cgrand/sjacket/test.clj
+++ b/test/net/cgrand/sjacket/test.clj
@@ -27,3 +27,14 @@
 "(z (fn [] a ;comment
     b)) (4/2
          d))")))
+
+(def incomplete-string-input
+"\"Hi,
+")
+
+(deftest incomplete-strings
+  (is (= :net.cgrand.parsley/unfinished
+         (:tag (p/parser incomplete-string-input))))
+  (is (= incomplete-string-input
+         (sj/str-pt (p/parser incomplete-string-input)))))
+


### PR DESCRIPTION
I believe this fixes the issue I was having in #1. It adds a test for the specific case in question, and I haven't been able to find others that will break.

My confusion turned out to be that I just hadn't yet learned about `net.cgrand.parsley/unspaced`. 
