### PR TITLE
Handle regexes

### DIFF
--- a/src/net/cgrand/sjacket/parser.clj
+++ b/src/net/cgrand/sjacket/parser.clj
@@ -57,7 +57,11 @@
                            ["\\u" {\0 \9} (re/repeat constituent-char 3 3)]
                            ["\\" {\0 \9} (re/repeat constituent-char 0 2)]}))
                "\""])
-   :regex "#TODO" ; TODO
+   :regex [(re/regex \# (re/?= \"))
+           \"
+           (re/regex (re/* #{(cs/not \" \\)
+                             [\\ cs/any-char]}))
+           \"]
    ;; numbers should be validated but this is the exact "scope" of a number
    :number (re/regex (re/? #{\+ \-}) {\0 \9} (re/* constituent-char))
    :kw.ns (re/regex start-token-char

--- a/test/net/cgrand/sjacket/test.clj
+++ b/test/net/cgrand/sjacket/test.clj
@@ -58,10 +58,8 @@
 (deftest dispatch-macros
   (is (= [:meta] (parsed-tags "#^{:foo 1} hi"))) ; old style meta
   (is (= [:var] (parsed-tags "#'foo")))
-
-  ; TODO
-  ; (is (= [:regex] (parsed-tags "#\"foo\"")))
-
+  (is (= [:regex]
+         (parsed-tags "#\"foo\\\"\\d+foo\""))) ; without escapes: #"foo\"\d+foo"
   (is (= [:fn] (parsed-tags "#(* % %)")))
   (is (= [:set] (parsed-tags "#{1 2 3}")))
   (is (= [:eval] (parsed-tags "#=(+ 1 2)")))


### PR DESCRIPTION
This adds parsing for regexes, which we talked briefly about in the comments for #3. 

This could get smarter, to require that the regexes actually be valid (e.g. `\d` and `\w` are ok, but `\y` is not). For now I was considering that to be out of scope, but wanted to mention it in case that's what you meant when you said you wanted regexes to be "on par with strings".
