### PR TITLE
Namespace-qualified keywords

### DIFF
--- a/src/net/cgrand/sjacket/parser.clj
+++ b/src/net/cgrand/sjacket/parser.clj
@@ -64,9 +64,6 @@
            \"]
    ;; numbers should be validated but this is the exact "scope" of a number
    :number (re/regex (re/? #{\+ \-}) {\0 \9} (re/* constituent-char))
-   :kw.ns (re/regex start-token-char
-                 (re/* token-char)
-                 (re/?= \/))
    :unrestricted.name (token #{"/"
                                [start-token-char (re/* (cs/- token-char \/))]})
    :sym.ns (re/regex start-token-char
@@ -80,9 +77,12 @@
                    [(cs/+ start-token-char \%) (re/* (cs/- token-char \/))]}))
    :symbol #{(p/unspaced :sym.ns "/" :unrestricted.name)
              :sym.name}
-   :keyword #{(p/unspaced #{":" "::"} :kw.ns "/" :unrestricted.name)
-              (p/unspaced #{":" "::"} :unrestricted.name)}
-   
+   :kw.ns (re/regex start-token-char
+                 (re/* token-char)
+                 (re/?= \/))
+   :keyword [(re/regex (re/repeat ":" 1 2))
+             #{(p/unspaced :kw.ns "/" :unrestricted.name)
+               (p/unspaced :unrestricted.name)}]
    :list ["(" :sexpr* ")"]
    :vector ["[" :sexpr* "]"]
    :map ["{" :sexpr* "}"]

--- a/test/net/cgrand/sjacket/test.clj
+++ b/test/net/cgrand/sjacket/test.clj
@@ -69,3 +69,15 @@
          (parsed-tags "#<Foo something>")))
   (is (= [:discard] (parsed-tags "#_foo"))))
 
+(defn- parsed-tag-and-content [input]
+  (let [parse-tree (p/parser input)]
+    (map (juxt :tag (comp first :content))
+         (:content parse-tree))))
+
+(deftest keywords
+  (is (= [[:keyword ":"]] (parsed-tag-and-content ":foo")))
+  (is (= [[:keyword "::"]] (parsed-tag-and-content "::foo")))
+  (is (= [[:keyword ":"]] (parsed-tag-and-content ":clojure.core/map")))
+  (is (= [[:keyword ":"]] (parsed-tag-and-content ":core/map")))
+  (is (= [[:keyword "::"]] (parsed-tag-and-content "::foo/bar")))
+  (is (= [[:keyword "::"]] (parsed-tag-and-content "::foo.bar/baz"))))


### PR DESCRIPTION
There was an ambiguous match error on any ns-qualified keywords. This patch prevents that error.

It'd need to be applied on top of the regexes pull request I have open (#6).
