### PR TITLE
Allow more characters to be parsed

### DIFF
--- a/src/net/cgrand/sjacket/parser.clj
+++ b/src/net/cgrand/sjacket/parser.clj
@@ -48,7 +48,11 @@
              :unreadable :eval :reader-literal}
    :nil (token "nil")
    :boolean #{(token "true") (token "false")}
-   :char (re/regex \\ (cs/not whitespace-char) (re/* constituent-char))
+   :char (p/unspaced
+           [\\
+            (re/regex
+              cs/any-char
+              (re/* constituent-char))])
    :string (p/unspaced
               ["\""
                (re/regex

--- a/test/net/cgrand/sjacket/test.clj
+++ b/test/net/cgrand/sjacket/test.clj
@@ -63,6 +63,8 @@
   (is (= [:char] (parsed-tags "\\;")))
   (is (= [:char] (parsed-tags "\\@")))
   (is (= [:char] (parsed-tags "\\^")))
+  (is (= [:char] (parsed-tags "\\ ")))
+  (is (= [:char] (parsed-tags "\\\n")))
   (is (= [:char :whitespace] (parsed-tags "\\f ")))
   (is (= [:list] (parsed-tags "(comment \\a)")))
   (is (= [:vector] (parsed-tags "[\\a]")))


### PR DESCRIPTION
Characters like `\"` and `\%` (included in `macro-chars`) were not parsing. This top commit allows them to be parsed.

Incidentally, I'm happy to keep sending pull requests, but I understand they may be a lot of work to manage, especially when several stack up and there are merge problems depending on ordering. Currently I'm managing my own release of sjacket in clojars from my fork, which is unfortunate since others interested in using a clojure parser may not know about it. So I would love to either extract the parser bits into a separate repository or have some other way that I can get fixes into a release in a more "official" way.
