### PR TITLE
Handle signed ratios

### DIFF
--- a/src/net/cgrand/sjacket/parser.clj
+++ b/src/net/cgrand/sjacket/parser.clj
@@ -67,13 +67,15 @@
    :number (re/regex (re/? #{\+ \-}) {\0 \9} (re/* constituent-char))
    :unrestricted.name (token #{"/"
                                [start-token-char (re/* (cs/- token-char \/))]})
-   :sym.ns (re/regex start-token-char
-                 (re/* token-char)
-                 (re/?= \/))
+   :sym.ns (re/regex (re/?! #{(token #{"true" "false" "nil"})
+                              [#{\+ \-} {\0 \9}]})
+                     start-token-char
+                     (re/* token-char)
+                     (re/?= \/))
    :sym.name (re/regex
                (re/?! #{(token #{"true" "false" "nil"})
                         [#{\+ \-} {\0 \9}]})
-               (token 
+               (token
                  #{"/"
                    [(cs/+ start-token-char \%) (re/* (cs/- token-char \/))]}))
    :symbol #{(p/unspaced :sym.ns "/" :unrestricted.name)

--- a/test/net/cgrand/sjacket/test.clj
+++ b/test/net/cgrand/sjacket/test.clj
@@ -118,10 +118,17 @@
   (is (= [:number] (parsed-tags "1")))
   (is (= [:number] (parsed-tags "12")))
   (is (= [:number] (parsed-tags "-1")))
+  (is (= [:number] (parsed-tags "+1")))
   (is (= [:number] (parsed-tags "1e14")))
   (is (= [:number] (parsed-tags "15N")))
   (is (= [:number] (parsed-tags "1.5M")))
-  (is (= [:number] (parsed-tags "1.03e14"))))
+  (is (= [:number] (parsed-tags "1.03e14")))
+  (is (= [:number] (parsed-tags "-1.03e14")))
+  (is (= [:number] (parsed-tags "1.03e-14")))
+  (is (= [:number] (parsed-tags "+1.03e+14")))
+  (is (= [:number] (parsed-tags "4/3")))
+  (is (= [:number] (parsed-tags "-4/3")))
+  (is (= [:number] (parsed-tags "+4/3"))))
 
 (deftest dispatch-macros
   (is (= [:meta] (parsed-tags "#^{:foo 1} hi"))) ; old style meta
@@ -181,7 +188,7 @@
   (is (p/parser (slurp (clojure.java.io/resource "clojure/walk.clj"))))
   (is (p/parser (slurp (clojure.java.io/resource "clojure/xml.clj"))))
   (is (p/parser (slurp (clojure.java.io/resource "clojure/zip.clj"))))
-  
+
   (is (p/parser (slurp (clojure.java.io/resource "clojure/java/browse.clj"))))
   (is (p/parser (slurp (clojure.java.io/resource "clojure/java/browse_ui.clj"))))
   (is (p/parser (slurp (clojure.java.io/resource "clojure/java/io.clj"))))


### PR DESCRIPTION
Positive & negative ratios were getting ambiguous match errors. I suspect there's a way to get rid of this duplication between `:sym.name` and `:sym.ns`, but I wasn't successful with my attempts.
