### PR TITLE
Number-like keywords

### DIFF
--- a/test/net/cgrand/sjacket/test.clj
+++ b/test/net/cgrand/sjacket/test.clj
@@ -150,10 +150,15 @@
          (:content parse-tree))))
 
 (deftest keywords
+  (is (= [[:keyword ":"]] (parsed-tag-and-content ":1")))
+  (is (= [[:keyword ":"]] (parsed-tag-and-content ":42")))
+  (is (= [[:keyword ":"]] (parsed-tag-and-content ":42/a")))
+  (is (= [[:keyword ":"]] (parsed-tag-and-content ":a/42")))
   (is (= [[:keyword ":"]] (parsed-tag-and-content ":foo")))
   (is (= [[:keyword "::"]] (parsed-tag-and-content "::foo")))
   (is (= [[:keyword ":"]] (parsed-tag-and-content ":clojure.core/map")))
   (is (= [[:keyword ":"]] (parsed-tag-and-content ":core/map")))
+  (is (= [[:keyword "::"]] (parsed-tag-and-content "::100")))
   (is (= [[:keyword "::"]] (parsed-tag-and-content "::foo/bar")))
   (is (= [[:keyword "::"]] (parsed-tag-and-content "::foo.bar/baz"))))
 


### PR DESCRIPTION
This is because of CLJ-1003/CLJ-1252/CLJ-1286 (brought up as a REPLy bug by https://github.com/trptcolin/reply/issues/132).

This PR is on top of the one from last year for signed ratios.
