### PR TITLE
Slash symbol

### DIFF
--- a/src/net/cgrand/sjacket/parser.clj
+++ b/src/net/cgrand/sjacket/parser.clj
@@ -75,7 +75,7 @@
    :sym.ns (re/regex (re/?! #{(token #{"true" "false" "nil"})
                               [#{\+ \-} {\0 \9}]})
                      start-token-char
-                     (re/* token-char)
+                     (re/* (cs/- token-char \/))
                      (re/?= \/))
    :sym.name (re/regex
                (re/?! #{(token #{"true" "false" "nil"})

--- a/test/net/cgrand/sjacket/test.clj
+++ b/test/net/cgrand/sjacket/test.clj
@@ -112,6 +112,7 @@
   (is (= [:symbol] (parsed-tags "main")))
   (is (= [:symbol] (parsed-tags "foo/bar")))
   (is (= [:symbol] (parsed-tags "foo.core/is-bar-baz?")))
+  (is (= [:symbol] (parsed-tags "clojure.core//")))
   (is (= [:symbol] (parsed-tags "-main"))))
 
 (deftest numbers


### PR DESCRIPTION
This is on top of my previous two PRs and handles the case of parsing things like `clojure.core//`,  http://dev.clojure.org/jira/browse/CLJ-873, and (by coincidence) http://dev.clojure.org/jira/browse/CLJ-1324
